### PR TITLE
start-tests: keep the CPU stress test running for the requested duration

### DIFF
--- a/start-tests.sh
+++ b/start-tests.sh
@@ -285,6 +285,11 @@ main() {
     # Wait for system monitoring to complete
     if [ "$RUN_TEMPERATURE" = true ]; then
         wait $MONITOR_PID
+    elif [ "$RUN_CPU_STRESS" = true ]; then
+        # Nothing else is keeping time, so hold here for the requested duration.
+        # cpu_test.sh runs stress-ng until the kill below, so without this the
+        # stress test gets killed immediately after it starts.
+        sleep $((TEST_DURATION * 60))
     fi
     
     # Kill CPU stress test when monitoring is done


### PR DESCRIPTION
The only blocking wait in `main()` is for the temperature monitor:

```bash
if [ "$RUN_TEMPERATURE" = true ]; then
    wait $MONITOR_PID
fi
```

`--cpu-stress` is its own option in `--help`, so you can select it without `--temperature`. When you do, the script starts `cpu/cpu_test.sh` in the background, skips that wait, and falls straight into the kill block a few lines down that reads the PID marker and kills `stress-ng`. `cpu_test.sh` has no timer of its own — it says so itself, "Duration: Infinite (until killed by main script)" — so the stress test dies right after it starts and the script still prints "All tests completed!".

`./start-tests.sh --cpu-stress --time 1` finished in 2 seconds here instead of 60.

Added a fallback wait for the case where nothing else is keeping time. It's an `elif`, so any run that includes `--temperature` (including `--all`) keeps using the monitor as the timekeeper and is unaffected.

I don't have an RK3576 board, so I tested the orchestration on a Linux box with a `stress-ng` stub on PATH that sleeps until killed. Before the change `--cpu-stress --time 1` took 2s, after it takes 61s (60s plus the existing 1s cleanup sleep). `--temperature --cpu-stress --time 1` still waits on the monitor rather than adding a second delay.
