### PR TITLE
Report a failed CPU or GPU stress test instead of always passing

### DIFF
--- a/common/generate_combined_report.py
+++ b/common/generate_combined_report.py
@@ -284,10 +284,10 @@ def generate_combined_report(results_dir):
     if os.path.exists(cpu_stress_marker_file):
         with open(cpu_stress_marker_file, 'r') as f:
             marker_content = f.read()
-            if 'CPU_STRESS=RUNNING' in marker_content or 'PID=' in marker_content:
-                cpu_stress_status = 'success'  # Assume success if marker exists
-            elif 'STATUS=FAILED' in marker_content:
+            if 'STATUS=FAILED' in marker_content:
                 cpu_stress_status = 'failed'
+            elif 'CPU_STRESS=RUNNING' in marker_content or 'PID=' in marker_content:
+                cpu_stress_status = 'success'
     
     # Read CPU stress log content
     cpu_stress_log_file = os.path.join(results_dir, 'cpu_stress.log')
@@ -304,10 +304,10 @@ def generate_combined_report(results_dir):
     if os.path.exists(gpu_stress_marker_file):
         with open(gpu_stress_marker_file, 'r') as f:
             marker_content = f.read()
-            if 'GPU_STRESS=RUNNING' in marker_content or 'PID=' in marker_content:
-                gpu_stress_status = 'success'  # Assume success if marker exists
-            elif 'STATUS=FAILED' in marker_content:
+            if 'STATUS=FAILED' in marker_content:
                 gpu_stress_status = 'failed'
+            elif 'GPU_STRESS=RUNNING' in marker_content or 'PID=' in marker_content:
+                gpu_stress_status = 'success'
     
     # Read GPU stress log content
     gpu_stress_log_file = os.path.join(results_dir, 'gpu_stress.log')

--- a/cpu/cpu_test.sh
+++ b/cpu/cpu_test.sh
@@ -37,6 +37,14 @@ echo "CPU stress test started (PID: $STRESS_PID)"
 # Update marker file with PID for the main script to kill later
 echo "PID=${STRESS_PID}" >> "${RESULTS_DIR}/cpu_stress_marker.txt"
 
+# stress-ng can exit straight away (unsupported option, cgroup limit, no memory).
+# Record that so the report doesn't count a test that never ran as a pass.
+sleep 1
+if ! kill -0 "${STRESS_PID}" 2>/dev/null; then
+    echo "STATUS=FAILED" >> "${RESULTS_DIR}/cpu_stress_marker.txt"
+    echo "CPU stress test exited immediately, see cpu_stress.log"
+fi
+
 # Keep running until killed by main script
 wait $STRESS_PID 2>/dev/null
 

--- a/gpu/gpu_test.sh
+++ b/gpu/gpu_test.sh
@@ -103,6 +103,20 @@ echo "PIDs: $PID_LIST"
 # Update marker file with PIDs for the main script to kill later
 echo "PID=${PID_LIST}" >> "${RESULTS_DIR}/gpu_stress_marker.txt"
 
+# glmark2 exits straight away without a working GL context. Record that so the
+# report doesn't count a test that never ran as a pass.
+sleep 1
+GPU_STRESS_ALIVE=false
+for PID in $PID_LIST; do
+    if kill -0 "$PID" 2>/dev/null; then
+        GPU_STRESS_ALIVE=true
+    fi
+done
+if [ "$GPU_STRESS_ALIVE" = false ]; then
+    echo "STATUS=FAILED" >> "${RESULTS_DIR}/gpu_stress_marker.txt"
+    echo "GPU stress processes exited immediately, see gpu_stress.log"
+fi
+
 # Show countdown dialog using yad if available
 if [ "$YAD_AVAILABLE" = true ]; then
     # Calculate timeout in seconds


### PR DESCRIPTION
The CPU and GPU stress tests report a pass in the board report even when the stress process dies on startup and no load is ever applied.

Two things combine to cause it.

`generate_combined_report.py` checks the marker file like this:

```python
if 'CPU_STRESS=RUNNING' in marker_content or 'PID=' in marker_content:
    cpu_stress_status = 'success'  # Assume success if marker exists
elif 'STATUS=FAILED' in marker_content:
    cpu_stress_status = 'failed'
```

`cpu_test.sh` writes `CPU_STRESS=RUNNING` at line 21 and `PID=` at line 38, both unconditionally, so the first branch always matches and the `STATUS=FAILED` branch can't be reached. Nothing writes `STATUS=FAILED` in the first place, so even reordering alone wouldn't change anything. `gpu_test.sh` and the GPU half of the report have the same shape.

So I did both halves: check `STATUS=FAILED` first, and actually write it when the stress process isn't alive a second after launch. For the GPU that means checking all four PIDs and only marking failed if none survived.

Reproduced with a `stress-ng` stub that exits 1 immediately, running the real `cpu_test.sh`:

```
CPU_STRESS=RUNNING
START_TIME=2026-07-27 13:50:24
DURATION=INFINITE
PID=72318
STATUS=FAILED      <- new
```

Same marker file through both versions of the check:

```
fixed logic  -> failed
old logic    -> success
```

The one-second sleep is there because the PID exists for a moment either way, so `kill -0` right after `$!` would pass even for a process that's already on its way out. It only delays the two stress scripts by a second each.

Worth saying: I could only test this on a normal x86 Linux box with stubbed binaries, not on an RK3576 board, so a look from someone with hardware would be good — particularly on whether one second is enough headroom for glmark2 to get going on that GPU.

One thing worth heading off: the `kill -0` check would be wrong if a stress run could legitimately finish inside that second. It can't here — `stress-ng --cpu 0 --metrics-brief` is started with no `--timeout`, and all four glmark2 processes use `--run-forever`. Both are meant to run until `start-tests.sh` kills them, so a process that's gone after a second has died, not finished.
