### PR TITLE
Don't report a PipeWire restart that didn't happen

### DIFF
--- a/sound/audio-driver-restart.sh
+++ b/sound/audio-driver-restart.sh
@@ -73,9 +73,14 @@ if aplay -l 2>/dev/null | grep -q "NAU8822"; then
     # Restart PipeWire to pick up the new card
     if command -v pipewire >/dev/null 2>&1; then
         log "Restarting PipeWire to detect new sound card..."
-        systemctl --user restart pipewire pipewire-pulse wireplumber 2>/dev/null || true
-        sleep 1
-        log "PipeWire restarted"
+        if systemctl --user restart pipewire pipewire-pulse wireplumber 2>/dev/null; then
+            sleep 1
+            log "PipeWire restarted"
+        else
+            warn "Could not restart PipeWire. This script runs as root, so --user targets"
+            warn "root's session rather than the desktop user's. Restart it from that user"
+            warn "if the card is still missing there."
+        fi
     fi
 else
     err "NAU8822 sound card still not present after rebind"


### PR DESCRIPTION
`audio-driver-restart.sh` always reports the PipeWire restart as having worked:

```bash
systemctl --user restart pipewire pipewire-pulse wireplumber 2>/dev/null || true
sleep 1
log "PipeWire restarted"
```

The error goes to `/dev/null`, `|| true` swallows the exit status, and the success line runs unconditionally.

That path can't really succeed as written. The script requires root at the top (`[[ $EUID -ne 0 ]] && exit 1`), and `systemctl --user` as root talks to root's own user manager, not the desktop user's session that owns the audio stack. So whoever runs this to fix a silent sound card is told PipeWire was restarted when nothing happened on the session that matters, and stops digging.

This keeps the behaviour non-fatal but stops it claiming success, and says why so the operator knows where to look. I left the actual user-session targeting alone on purpose — resolving the right uid (`loginctl` + `runuser`, or `XDG_RUNTIME_DIR`) is a design call, and I'd rather not guess at a convention for your test rigs. Happy to follow up with that if you want it.

The rebind logic above it is untouched.
